### PR TITLE
feat(RHTAPREL-806): update operator toolkit refrence

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -5,7 +5,7 @@ plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
 projectName: operator-toolkit-example
-repo: github.com/redhat-appstudio/operator-toolkit-example
+repo: github.com/konflux-ci/operator-toolkit-example
 resources:
 - api:
     crdVersion: v1
@@ -14,7 +14,7 @@ resources:
   domain: redhat.com
   group: appstudio
   kind: Bar
-  path: github.com/redhat-appstudio/operator-toolkit-example/api/v1alpha1
+  path: github.com/konflux-ci/operator-toolkit-example/api/v1alpha1
   version: v1alpha1
   webhooks:
     defaulting: true
@@ -27,6 +27,6 @@ resources:
   domain: redhat.com
   group: appstudio
   kind: Foo
-  path: github.com/redhat-appstudio/operator-toolkit-example/api/v1alpha1
+  path: github.com/konflux-ci/operator-toolkit-example/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # operator-toolkit-example
 
-This is a sample repository to show how to implement operators using [operator-tookit](https://github.com/redhat-appstudio/operator-toolkit).
+This is a sample repository to show how to implement operators using [operator-tookit](https://github.com/konflux-ci/operator-toolkit).
 
 ## Getting Started
 You’ll need a Kubernetes cluster to run against. You can use [KIND](https://sigs.k8s.io/kind) to get a local cluster for testing, or run against a remote cluster.

--- a/api/v1alpha1/foo_conditions.go
+++ b/api/v1alpha1/foo_conditions.go
@@ -1,6 +1,6 @@
 package v1alpha1
 
-import "github.com/redhat-appstudio/operator-toolkit/conditions"
+import "github.com/konflux-ci/operator-toolkit/conditions"
 
 const (
 	// healthConditionType is the type used to track the health of a Foo resource

--- a/api/v1alpha1/foo_types.go
+++ b/api/v1alpha1/foo_types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/redhat-appstudio/operator-toolkit/conditions"
+	"github.com/konflux-ci/operator-toolkit/conditions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/api/v1alpha1/webhooks/bar/suite_test.go
+++ b/api/v1alpha1/webhooks/bar/suite_test.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/redhat-appstudio/operator-toolkit-example/api/v1alpha1"
 	"net"
 	"path/filepath"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"testing"
 	"time"
+
+	"github.com/konflux-ci/operator-toolkit-example/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/api/v1alpha1/webhooks/bar/webhook.go
+++ b/api/v1alpha1/webhooks/bar/webhook.go
@@ -19,9 +19,10 @@ package bar
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
-	"github.com/redhat-appstudio/operator-toolkit-example/api/v1alpha1"
-	"github.com/redhat-appstudio/operator-toolkit-example/loader"
+	"github.com/konflux-ci/operator-toolkit-example/api/v1alpha1"
+	"github.com/konflux-ci/operator-toolkit-example/loader"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/api/v1alpha1/webhooks/webhooks.go
+++ b/api/v1alpha1/webhooks/webhooks.go
@@ -1,8 +1,8 @@
 package webhooks
 
 import (
-	"github.com/redhat-appstudio/operator-toolkit-example/api/v1alpha1/webhooks/bar"
-	"github.com/redhat-appstudio/operator-toolkit/webhook"
+	"github.com/konflux-ci/operator-toolkit-example/api/v1alpha1/webhooks/bar"
+	"github.com/konflux-ci/operator-toolkit/webhook"
 )
 
 // EnabledWebhooks is a slice containing references to all the webhooks that have to be registered

--- a/controllers/bar/adapter.go
+++ b/controllers/bar/adapter.go
@@ -2,10 +2,11 @@ package bar
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
-	"github.com/redhat-appstudio/operator-toolkit-example/api/v1alpha1"
-	"github.com/redhat-appstudio/operator-toolkit-example/loader"
-	"github.com/redhat-appstudio/operator-toolkit/controller"
+	"github.com/konflux-ci/operator-toolkit-example/api/v1alpha1"
+	"github.com/konflux-ci/operator-toolkit-example/loader"
+	"github.com/konflux-ci/operator-toolkit/controller"
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/controllers/bar/controller.go
+++ b/controllers/bar/controller.go
@@ -18,13 +18,14 @@ package bar
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
-	"github.com/redhat-appstudio/operator-toolkit-example/loader"
-	"github.com/redhat-appstudio/operator-toolkit/controller"
+	"github.com/konflux-ci/operator-toolkit-example/loader"
+	"github.com/konflux-ci/operator-toolkit/controller"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
-	"github.com/redhat-appstudio/operator-toolkit-example/api/v1alpha1"
+	"github.com/konflux-ci/operator-toolkit-example/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/controllers/bar/suite_test.go
+++ b/controllers/bar/suite_test.go
@@ -19,8 +19,9 @@ package bar
 import (
 	"context"
 	"path/filepath"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"testing"
+
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -32,7 +33,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	appstudiov1alpha1 "github.com/redhat-appstudio/operator-toolkit-example/api/v1alpha1"
+	appstudiov1alpha1 "github.com/konflux-ci/operator-toolkit-example/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -1,9 +1,9 @@
 package controllers
 
 import (
-	"github.com/redhat-appstudio/operator-toolkit-example/controllers/bar"
-	"github.com/redhat-appstudio/operator-toolkit-example/controllers/foo"
-	"github.com/redhat-appstudio/operator-toolkit/controller"
+	"github.com/konflux-ci/operator-toolkit-example/controllers/bar"
+	"github.com/konflux-ci/operator-toolkit-example/controllers/foo"
+	"github.com/konflux-ci/operator-toolkit/controller"
 )
 
 // EnabledControllers is a slice containing references to all the controllers that have to be registered

--- a/controllers/foo/adapter.go
+++ b/controllers/foo/adapter.go
@@ -2,10 +2,11 @@ package foo
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
-	"github.com/redhat-appstudio/operator-toolkit-example/api/v1alpha1"
-	"github.com/redhat-appstudio/operator-toolkit-example/loader"
-	"github.com/redhat-appstudio/operator-toolkit/controller"
+	"github.com/konflux-ci/operator-toolkit-example/api/v1alpha1"
+	"github.com/konflux-ci/operator-toolkit-example/loader"
+	"github.com/konflux-ci/operator-toolkit/controller"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/controllers/foo/controller.go
+++ b/controllers/foo/controller.go
@@ -18,10 +18,11 @@ package foo
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
-	"github.com/redhat-appstudio/operator-toolkit-example/api/v1alpha1"
-	"github.com/redhat-appstudio/operator-toolkit-example/loader"
-	"github.com/redhat-appstudio/operator-toolkit/controller"
+	"github.com/konflux-ci/operator-toolkit-example/api/v1alpha1"
+	"github.com/konflux-ci/operator-toolkit-example/loader"
+	"github.com/konflux-ci/operator-toolkit/controller"
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"

--- a/controllers/foo/suite_test.go
+++ b/controllers/foo/suite_test.go
@@ -19,8 +19,9 @@ package foo
 import (
 	"context"
 	"path/filepath"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"testing"
+
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -32,7 +33,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	appstudiov1alpha1 "github.com/redhat-appstudio/operator-toolkit-example/api/v1alpha1"
+	appstudiov1alpha1 "github.com/konflux-ci/operator-toolkit-example/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
-module github.com/redhat-appstudio/operator-toolkit-example
+module github.com/konflux-ci/operator-toolkit-example
 
 go 1.19
 
 require (
 	github.com/go-logr/logr v1.2.3
+	github.com/konflux-ci/operator-toolkit v0.0.0-20240402130556-ef6dcbeca69d
 	github.com/onsi/ginkgo/v2 v2.6.0
 	github.com/onsi/gomega v1.24.1
-	github.com/redhat-appstudio/operator-toolkit v0.0.0-20230705141436-de654b7a7aed
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
-github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -98,7 +96,6 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.14 h1:gm3vOOXfiuw5i9p5N9xJvfjvuofpyvLA9Wr6QfK5Fng=
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -159,7 +156,6 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
-github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -185,6 +181,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/konflux-ci/operator-toolkit v0.0.0-20240402130556-ef6dcbeca69d h1:z7j3mglNoXvIrw5Vz/Ul+izoITRaqYURPIWrFoEyHgI=
+github.com/konflux-ci/operator-toolkit v0.0.0-20240402130556-ef6dcbeca69d/go.mod h1:AcChx7FjpYSIkDvQgaUKyauuF0PXm3ivB5MqZSC9Eis=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -250,12 +248,6 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
-github.com/redhat-appstudio/operator-toolkit v0.0.0-20230629102132-9322a6882c56 h1:Su4DS3wc4Qr+n/YPNc81ttVNgHbo1xYowPiAq5R7u8M=
-github.com/redhat-appstudio/operator-toolkit v0.0.0-20230629102132-9322a6882c56/go.mod h1:6lVK58G/zkoxMoHAmYxzF6La8rMmCeZwOQk6i0dpYZo=
-github.com/redhat-appstudio/operator-toolkit v0.0.0-20230705135627-8f5d7055bdcc h1:4GU6mUsV0eMV2xg7JJm43Lb0QeZU5AZ8zi3YyeUwSX0=
-github.com/redhat-appstudio/operator-toolkit v0.0.0-20230705135627-8f5d7055bdcc/go.mod h1:6lVK58G/zkoxMoHAmYxzF6La8rMmCeZwOQk6i0dpYZo=
-github.com/redhat-appstudio/operator-toolkit v0.0.0-20230705141436-de654b7a7aed h1:4RQmIIyZPm7dZuwtPUvbTLQCNIkUR13zLIVlUE9nunA=
-github.com/redhat-appstudio/operator-toolkit v0.0.0-20230705141436-de654b7a7aed/go.mod h1:6lVK58G/zkoxMoHAmYxzF6La8rMmCeZwOQk6i0dpYZo=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -2,8 +2,9 @@ package loader
 
 import (
 	"context"
-	"github.com/redhat-appstudio/operator-toolkit-example/api/v1alpha1"
-	toolkit "github.com/redhat-appstudio/operator-toolkit/loader"
+
+	"github.com/konflux-ci/operator-toolkit-example/api/v1alpha1"
+	toolkit "github.com/konflux-ci/operator-toolkit/loader"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -2,8 +2,9 @@ package loader
 
 import (
 	"context"
-	"github.com/redhat-appstudio/operator-toolkit-example/api/v1alpha1"
-	toolkit "github.com/redhat-appstudio/operator-toolkit/loader"
+
+	"github.com/konflux-ci/operator-toolkit-example/api/v1alpha1"
+	toolkit "github.com/konflux-ci/operator-toolkit/loader"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/main.go
+++ b/main.go
@@ -18,11 +18,13 @@ package main
 
 import (
 	"flag"
-	"github.com/redhat-appstudio/operator-toolkit-example/api/v1alpha1/webhooks"
-	"github.com/redhat-appstudio/operator-toolkit-example/controllers"
-	"github.com/redhat-appstudio/operator-toolkit/controller"
-	"github.com/redhat-appstudio/operator-toolkit/webhook"
 	"os"
+
+	"github.com/konflux-ci/operator-toolkit-example/api/v1alpha1/webhooks"
+	"github.com/konflux-ci/operator-toolkit-example/controllers"
+	"github.com/konflux-ci/operator-toolkit/controller"
+	"github.com/konflux-ci/operator-toolkit/webhook"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -34,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	appstudiov1alpha1 "github.com/redhat-appstudio/operator-toolkit-example/api/v1alpha1"
+	appstudiov1alpha1 "github.com/konflux-ci/operator-toolkit-example/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
 This commit updates the `operator-toolkit` refrence
 as a result of migration to `konflux-ci` from `redhat-appstudio`
 more details parent EPIC:
 https://issues.redhat.com/browse/RHTAPREL-800